### PR TITLE
Refactor add_member_to_project session

### DIFF
--- a/services/project_service.py
+++ b/services/project_service.py
@@ -105,7 +105,16 @@ class ProjectService:
     async def add_member_to_project(project_id: int, user_discord_id: int) -> bool:
         """Add a member to a project."""
         async with get_async_session() as session:
-            project = await ProjectService.get_project_by_id(project_id)
+            result = await session.execute(
+                select(Project)
+                .options(
+                    selectinload(Project.members),
+                    selectinload(Project.tasks),
+                )
+                .where(Project.id == project_id)
+            )
+            project = result.scalar_one_or_none()
+
             if not project:
                 return False
             

--- a/tests/test_project_service.py
+++ b/tests/test_project_service.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from services.project_service import ProjectService
+from models import Project, User
+
+
+class TestProjectService:
+    @pytest.mark.asyncio
+    async def test_add_member_to_project(self):
+        fake_project = Project(name="Test Project")
+        fake_project.id = 1
+        fake_project.members = []
+
+        fake_user = User(username="tester", discord_id=123)
+        fake_user.id = 2
+
+        session_mock = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = fake_project
+        session_mock.execute.return_value = result_mock
+        session_mock.commit = AsyncMock()
+
+        with patch("services.project_service.get_async_session") as session_cm, \
+             patch("services.project_service.UserService.get_or_create_user", new=AsyncMock(return_value=fake_user)):
+            session_cm.return_value.__aenter__.return_value = session_mock
+            session_cm.return_value.__aexit__.return_value = None
+
+            result = await ProjectService.add_member_to_project(1, 123)
+
+            assert result is True
+            assert fake_user in fake_project.members
+            session_mock.commit.assert_awaited_once()
+


### PR DESCRIPTION
## Summary
- manage project lookup inside existing session when adding a member
- add a test for `ProjectService.add_member_to_project`

## Testing
- `make lint` *(fails: numerous style violations)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687d9620d604832088163e3c7a964a6a