### PR TITLE
Implement time entry service

### DIFF
--- a/bot/cogs/time_tracking.py
+++ b/bot/cogs/time_tracking.py
@@ -8,8 +8,7 @@ import discord
 from discord.ext import commands
 from discord import app_commands
 
-from models import TimeEntry
-from services import TaskService, UserService
+from services import TaskService, UserService, TimeEntryService
 
 logger = logging.getLogger(__name__)
 
@@ -104,8 +103,15 @@ class TimeTrackingCog(commands.Cog):
             )
             return
         
-        # TODO: Save time entry to database
-        # For now, just show the summary
+        # Save time entry to the database
+        await TimeEntryService.create_time_entry(
+            task_id=task_id,
+            user_id=user_id,
+            duration_hours=duration_hours,
+            description=description,
+            start_time=start_time,
+            end_time=end_time,
+        )
         
         embed = discord.Embed(
             title="⏹️ Timer Stopped",

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -3,5 +3,11 @@
 from .user_service import UserService
 from .task_service import TaskService
 from .project_service import ProjectService
+from .time_entry_service import TimeEntryService
 
-__all__ = ["UserService", "TaskService", "ProjectService"]
+__all__ = [
+    "UserService",
+    "TaskService",
+    "ProjectService",
+    "TimeEntryService",
+]

--- a/services/time_entry_service.py
+++ b/services/time_entry_service.py
@@ -41,23 +41,37 @@ class TimeEntryService:
             return entry
 
     @staticmethod
-    async def get_time_entries_for_user(user_id: int) -> List[TimeEntry]:
-        """Fetch all time entries for a specific user."""
+    async def get_time_entries_for_user(
+        user_id: int, limit: Optional[int] = None, offset: Optional[int] = None
+    ) -> List[TimeEntry]:
+        """Fetch time entries for a specific user with optional pagination."""
         async with get_async_session() as session:
-            result = await session.execute(
+            query = (
                 select(TimeEntry)
                 .options(selectinload(TimeEntry.task))
                 .where(TimeEntry.user_id == user_id)
             )
-            return result.scalars().all()
+            if limit is not None:
+                query = query.limit(limit)
+            if offset is not None:
+                query = query.offset(offset)
+            result = await session.execute(query)
+            return result.scalars()
 
     @staticmethod
-    async def get_time_entries_for_task(task_id: int) -> List[TimeEntry]:
-        """Fetch all time entries for a specific task."""
+    async def get_time_entries_for_task(
+        task_id: int, limit: Optional[int] = None, offset: Optional[int] = None
+    ) -> List[TimeEntry]:
+        """Fetch time entries for a specific task with optional pagination."""
         async with get_async_session() as session:
-            result = await session.execute(
+            query = (
                 select(TimeEntry)
                 .options(selectinload(TimeEntry.user))
                 .where(TimeEntry.task_id == task_id)
             )
-            return result.scalars().all()
+            if limit is not None:
+                query = query.limit(limit)
+            if offset is not None:
+                query = query.offset(offset)
+            result = await session.execute(query)
+            return result.scalars()

--- a/services/time_entry_service.py
+++ b/services/time_entry_service.py
@@ -1,0 +1,63 @@
+"""Service for managing time tracking entries."""
+
+import logging
+from typing import Optional, List
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from models import TimeEntry
+from utils import get_async_session
+
+logger = logging.getLogger(__name__)
+
+
+class TimeEntryService:
+    """Service for managing time entries."""
+
+    @staticmethod
+    async def create_time_entry(
+        task_id: int,
+        user_id: int,
+        duration_hours: float,
+        description: Optional[str] = None,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+    ) -> TimeEntry:
+        """Create and persist a time entry."""
+        async with get_async_session() as session:
+            entry = TimeEntry(
+                task_id=task_id,
+                user_id=user_id,
+                duration_hours=duration_hours,
+                description=description,
+                start_time=start_time,
+                end_time=end_time,
+            )
+            session.add(entry)
+            await session.commit()
+            await session.refresh(entry)
+            return entry
+
+    @staticmethod
+    async def get_time_entries_for_user(user_id: int) -> List[TimeEntry]:
+        """Fetch all time entries for a specific user."""
+        async with get_async_session() as session:
+            result = await session.execute(
+                select(TimeEntry)
+                .options(selectinload(TimeEntry.task))
+                .where(TimeEntry.user_id == user_id)
+            )
+            return result.scalars().all()
+
+    @staticmethod
+    async def get_time_entries_for_task(task_id: int) -> List[TimeEntry]:
+        """Fetch all time entries for a specific task."""
+        async with get_async_session() as session:
+            result = await session.execute(
+                select(TimeEntry)
+                .options(selectinload(TimeEntry.user))
+                .where(TimeEntry.task_id == task_id)
+            )
+            return result.scalars().all()

--- a/tests/test_time_entry_service.py
+++ b/tests/test_time_entry_service.py
@@ -1,0 +1,36 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone
+
+from services.time_entry_service import TimeEntryService
+from models import TimeEntry
+
+
+class TestTimeEntryService:
+    @pytest.mark.asyncio
+    async def test_create_time_entry(self):
+        session_mock = AsyncMock()
+        session_mock.commit = AsyncMock()
+        session_mock.refresh = AsyncMock()
+        session_mock.add = MagicMock()
+
+        with patch("services.time_entry_service.get_async_session") as session_cm:
+            session_cm.return_value.__aenter__.return_value = session_mock
+            session_cm.return_value.__aexit__.return_value = None
+
+            start = datetime.now(timezone.utc)
+            end = start
+
+            entry = await TimeEntryService.create_time_entry(
+                task_id=1,
+                user_id=2,
+                duration_hours=1.5,
+                description="work",
+                start_time=start,
+                end_time=end,
+            )
+
+            session_mock.add.assert_called_once()
+            session_mock.commit.assert_awaited_once()
+            session_mock.refresh.assert_awaited_once_with(entry)
+


### PR DESCRIPTION
## Summary
- add `TimeEntryService` for managing `TimeEntry` records
- use `TimeEntryService` when stopping timers
- expose `TimeEntryService` in services package
- test time entry service creation

## Testing
- `make test`
- `make lint` *(fails: flake8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687e600147fc8320b9d053831d46b4fe